### PR TITLE
Fix typo: root.inorder() takes no parameter key

### DIFF
--- a/BST.md
+++ b/BST.md
@@ -261,7 +261,7 @@ public class BST {
         if (root == null)
             return;
         else
-            root.inorder(key);
+            root.inorder();
     }
     
     public void preorder() {


### PR DESCRIPTION
Namah Shivaya,

I found out the following typo in BST implementation markdown, and I was a bit confused for a sec. 