### PR TITLE
Reassigned prev link in delete function

### DIFF
--- a/DoublyLinkedList.md
+++ b/DoublyLinkedList.md
@@ -134,6 +134,8 @@ public class DoublyLinkedList {
         // temp is the node to be deleted (next to curr)
         DNode temp = curr.next;
         curr.next = temp.next; // reassign the links
+        temp.next.prev=temp.prev; 
+        temp.prev=null;
         temp.next = null;
     }
 }


### PR DESCRIPTION
Without reassigning the prev links, we will still go to the deleted nodes when we traverse from tail.